### PR TITLE
Creates `POST /validate-rule`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,2 @@
 # Rule-Validation-Api
+[![Build Status](https://travis-ci.com/NonsoAmadi10/Rule-Validation-Api.svg?branch=main)](https://travis-ci.com/NonsoAmadi10/Rule-Validation-Api)

--- a/package-lock.json
+++ b/package-lock.json
@@ -5445,6 +5445,19 @@
         "is-typedarray": "^1.0.0"
       }
     },
+    "underscore": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz",
+      "integrity": "sha1-izixDKze9jM3uLJOT/htRa6lKag="
+    },
+    "underscore-contrib": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/underscore-contrib/-/underscore-contrib-0.3.0.tgz",
+      "integrity": "sha1-ZltmwkeD+PorGMn4y7Dix9SMJsc=",
+      "requires": {
+        "underscore": "1.6.0"
+      }
+    },
     "unicode-canonical-property-names-ecmascript": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-1.0.4.tgz",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
     "@babel/runtime": "^7.12.5",
     "dotenv": "^8.2.0",
     "eslint": "^7.18.0",
-    "express": "^4.17.1"
+    "express": "^4.17.1",
+    "lodash": "^4.17.20"
   },
   "devDependencies": {
     "@babel/cli": "^7.12.10",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "dotenv": "^8.2.0",
     "eslint": "^7.18.0",
     "express": "^4.17.1",
-    "lodash": "^4.17.20"
+    "underscore-contrib": "^0.3.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.12.10",

--- a/src/controllers.js
+++ b/src/controllers.js
@@ -1,4 +1,6 @@
-import { Response } from './utils'
+import { Response, checkValidField } from './utils';
+import _ from 'lodash';
+
 class LogicController {
 
     static info(req, res) {
@@ -11,6 +13,37 @@ class LogicController {
         };
 
         return Response("My Rule-Validation API",'success', myInfo, res);
+    }
+
+    static validateRule(req, res){
+        const erresponse = (message, code) => res.status(code).send({message, status: "error", data: null});
+        const {rule, data} = req.body;
+        const {field, condition, condition_value} = rule;
+    
+        
+        
+        let requiredDataField;
+        /** check if the field in the rule object is a nested object or not*/
+         if(field.match(/\./)) {
+            const splitWord = field.split('.');
+            /** The nesting should not be more than two levels */
+            if(splitWord.length > 3){
+                return erresponse(`field ${field} nesting should not be more than two levels.`, 400)
+            }
+            requiredDataField = _.get(data, field);
+         }else {
+        /** extract the required field from the data object so that you can compare */
+            requiredDataField = field
+         }
+
+         /** check if the field specified in the rule object is missing from the data passed */
+        
+        if(!requiredDataField && !checkValidField(field, data)) return erresponse(`field ${field} is missing from data.`, 400);
+         console.log(requiredDataField)
+        
+        
+        
+        return res.send({})
     }
 }
 

--- a/src/controllers.js
+++ b/src/controllers.js
@@ -1,0 +1,17 @@
+import { successResponse } from './utils'
+class LogicController {
+
+    static info(req, res) {
+        const myInfo = {
+            name: "Amadi Justice Chinonso",
+            github: "@NonsoAmadi10",
+            email: "nonsoamadi@aol.com",
+            mobile: "08086749490",
+            twitter: "@jackhoudini__"
+        };
+
+        return successResponse("My Rule-Validation API", myInfo, res);
+    }
+}
+
+export default LogicController;

--- a/src/controllers.js
+++ b/src/controllers.js
@@ -44,6 +44,7 @@ class LogicController {
         if(!checkValidField(field, data)) return erresponse(`field ${field} is missing from data.`, 400);
          /** extract the required field from the data object so that you can compare */
             if(isObj(data)){
+                console.log(isObj(data))
                 requiredDataField = getObjValue(data, field);
             }else{
          requiredDataField = typeof data =="array" ? data.toString() : data; 
@@ -77,7 +78,6 @@ class LogicController {
               return Response(`field ${field} successfully validated.`, 'success', validData, res, 200);
           }else{
         
-          console.log(requiredDataField)
         const errData = responseData(true, field, requiredDataField, condition, condition_value);
         return erresponse(`field ${field} failed validation.`,  400, errData);
     }

--- a/src/controllers.js
+++ b/src/controllers.js
@@ -1,4 +1,4 @@
-import { successResponse } from './utils'
+import { Response } from './utils'
 class LogicController {
 
     static info(req, res) {
@@ -10,7 +10,7 @@ class LogicController {
             twitter: "@jackhoudini__"
         };
 
-        return successResponse("My Rule-Validation API", myInfo, res);
+        return Response("My Rule-Validation API",'success', myInfo, res);
     }
 }
 

--- a/src/controllers.js
+++ b/src/controllers.js
@@ -1,5 +1,5 @@
-import { Response, checkValidField } from './utils';
-import _ from 'underscore-contrib';
+import { Response, checkValidField,getObjValue, isObj } from './utils';
+
 
 class LogicController {
 
@@ -16,22 +16,20 @@ class LogicController {
     }
 
     static validateRule(req, res){
-        const erresponse = (message, code) => res.status(code).send({message, status: "error", data: null});
+        const erresponse = (message,code=400, data=null) => res.status(code).send({message, status: "error", data});
         const {rule, data} = req.body;
         const {field, condition, condition_value} = rule;
     
-        
-        
         let requiredDataField;
         /** check if the field in the rule object is a nested object or not*/
-         if(field.match(/\./)) {
+         if(!Number(field) && typeof field == 'string' && field.match(/\./)) {
             const splitWord = field.split('.');
             
             /** The nesting should not be more than two levels */
             if(splitWord.length > 3){
                 return erresponse(`field ${field} nesting should not be more than two levels.`, 400)
             }
-         let required = _.getPath(data, field);
+         let required = getObjValue(data, field);
          /**Incase of gramatival error like 'mission.cat' instead of 'missions.cat' you want to still throw a missing field error */
          if (required !== undefined){
              requiredDataField = required
@@ -45,17 +43,45 @@ class LogicController {
         
         if(!checkValidField(field, data)) return erresponse(`field ${field} is missing from data.`, 400);
          /** extract the required field from the data object so that you can compare */
+            if(isObj(data)){
+                requiredDataField = getObjValue(data, field);
+            }else{
+         requiredDataField = typeof data =="array" ? data.toString() : data; 
+         }
+        }
 
-         requiredDataField = data[0] || data; 
+         /** Create a Javascript Object that handles the comparison*/
+         const operators = {
+             'gte': function(a, b) { return a >= b},
+              'gt': function(a, b) { return a > b},
+              'neq': function(a,b){ return a!= b},
+              'eq': function(a,b){ return a == b},
+              'contains': function(a, b) { return String(a).indexOf(String(b))}
+              
          }
 
-         /** The condition value to run the rule against */
-
-         
+            const responseData = (error, field, field_value, condition, condition_value) => {
+                return {
+                    validation: {
+                        error,
+                        field,
+                        field_value,
+                        condition,
+                        condition_value
+                    }
+                }
+            }
+         /** Compare the value and return the result */
+          if(operators[condition](requiredDataField, condition_value)){
+              const validData = responseData(false, field, requiredDataField, condition, condition_value);
+              return Response(`field ${field} successfully validated.`, 'success', validData, res, 200);
+          }else{
         
-        
-        return res.send({})
+          console.log(requiredDataField)
+        const errData = responseData(true, field, requiredDataField, condition, condition_value);
+        return erresponse(`field ${field} failed validation.`,  400, errData);
     }
+}
 }
 
 export default LogicController;

--- a/src/controllers.js
+++ b/src/controllers.js
@@ -1,5 +1,5 @@
 import { Response, checkValidField } from './utils';
-import _ from 'lodash';
+import _ from 'underscore-contrib';
 
 class LogicController {
 
@@ -26,21 +26,32 @@ class LogicController {
         /** check if the field in the rule object is a nested object or not*/
          if(field.match(/\./)) {
             const splitWord = field.split('.');
+            
             /** The nesting should not be more than two levels */
             if(splitWord.length > 3){
                 return erresponse(`field ${field} nesting should not be more than two levels.`, 400)
             }
-            requiredDataField = _.get(data, field);
-         }else {
-        /** extract the required field from the data object so that you can compare */
-            requiredDataField = field
+         let required = _.getPath(data, field);
+         /**Incase of gramatival error like 'mission.cat' instead of 'missions.cat' you want to still throw a missing field error */
+         if (required !== undefined){
+             requiredDataField = required
+         }else{
+           return erresponse(`field ${field} is missing from data.`, 400)  
          }
-
+            console.log(requiredDataField, field)
+         }else {
+       
          /** check if the field specified in the rule object is missing from the data passed */
         
-        if(!requiredDataField && !checkValidField(field, data)) return erresponse(`field ${field} is missing from data.`, 400);
-         console.log(requiredDataField)
-        
+        if(!checkValidField(field, data)) return erresponse(`field ${field} is missing from data.`, 400);
+         /** extract the required field from the data object so that you can compare */
+
+         requiredDataField = data[0] || data; 
+         }
+
+         /** The condition value to run the rule against */
+
+         
         
         
         return res.send({})

--- a/src/index.js
+++ b/src/index.js
@@ -1,10 +1,18 @@
 import express from 'express';
 import { config } from 'dotenv';
+import routes from './routes';
 
 config();
 const app = express();
+app.use(express.json());
+app.use(express.urlencoded({extended: false}));
+app.use('/', routes);
 
 
-const port = 3000 ;
+
+const port = process.env.PORT || 3000 ;
 
 app.listen(port, () => console.log("Server Running..."));
+
+
+export default  app;

--- a/src/middlewares.js
+++ b/src/middlewares.js
@@ -1,13 +1,37 @@
-import Response from './utils';
+import { checkValidRequestBody, isObj} from './utils';
 
 
+
+const checkEmpty = (input)=> {
+    const re = /^$/;
+    const testBody = re.test(input);
+    return testBody;
+  }
 
 export const sanitizer =(req, res, next) => {
+    const response = (message, code) => res.status(code).send({message, status: "error", data: null});
+    
+
     const {rule, data } = req.body;
+   
+    /** Check if the required request body data are present  */
+    if(!rule) return response('rule is required.', 400);
+    if(!data) return response('data is required.', 400);
 
-    if(!rule) return Response('rule is required.','error',null, res);
-    if(!data) return Response('data is required.', 'error', null, res);
+    /**Check if the rule field is an object type */
+    if(!isObj(rule)) return response('rule should be an object.', 400)
 
+
+    /** Check for invalid payload */
+    const validRequestBody = checkValidRequestBody(req.body);
+    if(validRequestBody.length > 0) return response('Invalid JSON payload passed.', 400)
+    const { field, condition, condition_value } = rule;
+      
+      /** Validate the rule fields */
+      if (checkEmpty(field)) return response('field is required in the rule object.', 400);
+      if (checkEmpty(condition)) return response('condition is required in the rule object.',400);
+      if (checkEmpty(condition_value)) return response('condition value is required in the rule object.',400);
     return next();
+    
 }
 

--- a/src/middlewares.js
+++ b/src/middlewares.js
@@ -31,6 +31,8 @@ export const sanitizer =(req, res, next) => {
       if (checkEmpty(field)) return response('field is required in the rule object.', 400);
       if (checkEmpty(condition)) return response('condition is required in the rule object.',400);
       if (checkEmpty(condition_value)) return response('condition value is required in the rule object.',400);
+      
+      
     return next();
     
 }

--- a/src/middlewares.js
+++ b/src/middlewares.js
@@ -1,0 +1,13 @@
+import Response from './utils';
+
+
+
+export const sanitizer =(req, res, next) => {
+    const {rule, data } = req.body;
+
+    if(!rule) return Response('rule is required.','error',null, res);
+    if(!data) return Response('data is required.', 'error', null, res);
+
+    return next();
+}
+

--- a/src/routes.js
+++ b/src/routes.js
@@ -1,11 +1,11 @@
 import { Router} from 'express';
 import LogicController from './controllers';
-import {san} from './middlewares';
+import {sanitizer} from './middlewares';
 
 const router = Router();
 
 router.get('', LogicController.info);
-router.post('validate-rule', sanitizer);
+router.post('/validate-rule', sanitizer, LogicController.validateRule);
 
 
 export default router;

--- a/src/routes.js
+++ b/src/routes.js
@@ -1,0 +1,9 @@
+import { Router} from 'express';
+import LogicController from './controllers';
+
+const router = Router();
+
+router.get('', LogicController.info);
+
+
+export default router;

--- a/src/routes.js
+++ b/src/routes.js
@@ -1,9 +1,11 @@
 import { Router} from 'express';
 import LogicController from './controllers';
+import {san} from './middlewares';
 
 const router = Router();
 
 router.get('', LogicController.info);
+router.post('validate-rule', sanitizer);
 
 
 export default router;

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,3 +1,5 @@
+import _ from 'underscore-contrib';
+
 export const Response =(message,status, data, res, statusCode=200) => {
     return res.status(statusCode).send({
         message,
@@ -19,14 +21,19 @@ export const isObj =(val)=> {
 export const checkValidField =(field, data)=> {
     const itsObj = isObj(data);
     const itsArr = Array.isArray(data);
-    if(!itsArr && isObj){
+    
+    if(!itsArr && data!=field && isObj){
         return data.hasOwnProperty(field)
-    }else{
-        if (data != field){
-            return data.includes(field);
-        }else{
-            return field == data;
-        }
     }
     
+    // if (itsArr && !isObj && data != field){
+    //     return data.includes(field);
+    // }
+
+    if(!itsArr && !itsObj && data == field) return field == data;
+
+    return data.includes(field)
+    
 }
+
+export const getObjValue =(obj, required)=> _.getPath(obj, required);

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,7 +1,31 @@
-export const Response =(message,status, data, res) => {
-    return res.send({
+export const Response =(message,status, data, res, statusCode=200) => {
+    return res.status(statusCode).send({
         message,
         status,
         data
     });
+}
+
+export const checkValidRequestBody =(obj)=> {
+    const checkKey = Object.keys(obj);
+    const validateRequest = checkKey.filter((keys) => keys !== 'data' && keys !== 'rule');
+
+    return validateRequest;
+
+}
+export const isObj =(val)=> {
+    return val === Object(val)
+}
+export const checkValidField =(field, data)=> {
+    const itsArr = Array.isArray(data);
+    if(!itsArr){
+        return true;
+    }else{
+        if (data != field){
+            return data.includes(field);
+        }else{
+            return field == data;
+        }
+    }
+    
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,0 +1,7 @@
+export const successResponse =(message, data, res) => {
+    return res.send({
+        message,
+        status: "success",
+        data
+    });
+}

--- a/src/utils.js
+++ b/src/utils.js
@@ -17,9 +17,10 @@ export const isObj =(val)=> {
     return val === Object(val)
 }
 export const checkValidField =(field, data)=> {
+    const itsObj = isObj(data);
     const itsArr = Array.isArray(data);
-    if(!itsArr){
-        return true;
+    if(!itsArr && isObj){
+        return data.hasOwnProperty(field)
     }else{
         if (data != field){
             return data.includes(field);

--- a/src/utils.js
+++ b/src/utils.js
@@ -16,7 +16,7 @@ export const checkValidRequestBody =(obj)=> {
 
 }
 export const isObj =(val)=> {
-    return val === Object(val)
+    return val === Object(val) && !Array.isArray(val)
 }
 export const checkValidField =(field, data)=> {
     const itsObj = isObj(data);

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,7 +1,7 @@
-export const successResponse =(message, data, res) => {
+export const Response =(message,status, data, res) => {
     return res.send({
         message,
-        status: "success",
+        status,
         data
     });
 }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -5,7 +5,7 @@ import app from '../src';
 chai.use(chaiHttp);
 
 
-describe('test', () => {
+describe('GET /', () => {
     it('should get my personal info', (done) => {
         chai.request(app)
         .get('/')
@@ -13,9 +13,144 @@ describe('test', () => {
             expect(res.status).to.be.equal(200);
             
         expect(res.body).to.be.a('object');
+        expect(res.body.message).to.equal('My Rule-Validation API')
         expect(res.body.data).to.have.all.keys(['name', 'github', 'email', 'twitter', 'mobile']);
         expect(res.body.data['github']).to.include('@')
         done();
-        } )
+        } );
     });
+});
+
+describe('POST /validate-rule', () => {
+    it('should check if the rule field is not passed', (done) => {
+        const body = {
+            data: {name: "James Holden", crew: "Rocinante", age: 34, position: "Captain",missions: 45}
+        }
+
+        chai.request(app)
+        .post('/validate-rule')
+        .send(body)
+        .end((err, res) => {
+            expect(res.status).to.equal(400);
+            expect(res.body.message).to.equal('rule is required.');
+            expect(res.body.data).to.equal(null);
+            expect(res.body.status).to.equal('error');
+            done();
+        });
+    });
+
+    it('should check if the data field is not passed', (done) => {
+        const body = { rule: { field: "missions", condition: "gte",condition_value: 30 }};
+
+        chai.request(app)
+        .post('/validate-rule')
+        .send(body)
+        .end((err, res) => {
+            expect(res.status).to.equal(400);
+            expect(res.body.message).to.equal('data is required.');
+            expect(res.body.data).to.equal(null);
+            expect(res.body.status).to.equal('error');
+            done();
+        });
+    });
+
+    it('should check if the rule field is an object', (done) => {
+        const body = {
+            rule: "hi",
+            data: {name: "James Holden", crew: "Rocinante", age: 34, position: "Captain",missions: 45}
+        };
+        chai.request(app)
+        .post('/validate-rule')
+        .send(body)
+        .end((err, res) => {
+            expect(res.status).to.equal(400);
+            expect(res.body.message).to.equal('rule should be an object.');
+            expect(res.body.data).to.equal(null);
+            expect(res.body.status).to.equal('error');
+            done();
+        });
+
+    });
+
+    it('should check for invalid JSON payload', (done) => {
+        const body = {
+            rule: { field: "missions", condition: "gte",condition_value: 30 },
+            data: {name: "James Holden", crew: "Rocinante", age: 34, position: "Captain",missions: 45},
+            name: "Nonso Amadi"
+        };
+        chai.request(app)
+        .post('/validate-rule')
+        .send(body)
+        .end((err, res) => {
+            expect(res.status).to.equal(400);
+            expect(res.body.message).to.equal('Invalid JSON payload passed.')
+            done();
+        });
+
+    });
+
+    it('should check if a field is empty in the rule object', (done) => {
+        const body = {
+            rule: { field: "", condition: "gte",condition_value: 30 },
+            data: {name: "James Holden", crew: "Rocinante", age: 34, position: "Captain",missions: 45},
+        };
+        chai.request(app)
+        .post('/validate-rule')
+        .send(body)
+        .end((err, res) => {
+            expect(res.status).to.equal(400);
+            expect(res.body.message).to.equal('field is required in the rule object.')
+            done();
+        });
+
+    });
+
+    it('should check if a field is empty in the rule object', (done) => {
+        const body = {
+            rule: { field: "missions", condition: "",condition_value: 30 },
+            data: {name: "James Holden", crew: "Rocinante", age: 34, position: "Captain",missions: 45},
+        };
+        chai.request(app)
+        .post('/validate-rule')
+        .send(body)
+        .end((err, res) => {
+            expect(res.status).to.equal(400);
+            expect(res.body.message).to.equal('condition is required in the rule object.')
+            done();
+        });
+
+    });
+
+    it('should check if a field is empty in the rule object', (done) => {
+        const body = {
+            rule: { field: "missions", condition: "gte",condition_value: "" },
+            data: {name: "James Holden", crew: "Rocinante", age: 34, position: "Captain",missions: 45},
+        };
+        chai.request(app)
+        .post('/validate-rule')
+        .send(body)
+        .end((err, res) => {
+            expect(res.status).to.equal(400);
+            expect(res.body.message).to.equal('condition value is required in the rule object.')
+            done();
+        });
+
+    });
+
+    it('should check if a rule field is missing in the data object', (done) => {
+        const body = {
+            rule: { field: "missions", condition: "gte",condition_value: 30 },
+            data: {name: "James Holden", crew: "Rocinante", age: 34, position: "Captain"},
+        };
+        chai.request(app)
+        .post('/validate-rule')
+        .send(body)
+        .end((err, res) => {
+            expect(res.status).to.equal(400);
+            expect(res.body.message).to.equal('field missions is missing from data.')
+            done();
+        });
+
+    });
+
 });

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -164,9 +164,75 @@ describe('POST /validate-rule', () => {
         .post('/validate-rule')
         .send(body)
         .end((err, res) => {
-        console.log(res.body)
+        
             expect(res.status).to.equal(200);
             expect(res.body.message).to.equal('field missions successfully validated.')
+            done();
+        });
+
+    });
+    it('should accept JSON data containing a rule and data field to validate the rule against.', (done) => {
+        const body = {
+            rule: { field: "missions.cat", condition: "gte",condition_value: 30 },
+            data: {name: "James Holden", crew: "Rocinante", age: 34, position: "Captain", missions: { cat: 45}},
+        };
+        chai.request(app)
+        .post('/validate-rule')
+        .send(body)
+        .end((err, res) => {
+        
+            expect(res.status).to.equal(200);
+            expect(res.body.message).to.equal('field missions.cat successfully validated.')
+            done();
+        });
+
+    });
+    it('should accept JSON data containing a rule and data of type array to validate the rule against.', (done) => {
+        const body = {
+            rule: { field: 45, condition: "gt",condition_value: 30 },
+            data: [45],
+        };
+        chai.request(app)
+        .post('/validate-rule')
+        .send(body)
+        .end((err, res) => {
+            expect(res.status).to.equal(200);
+            expect(res.body.message).to.equal('field 45 successfully validated.')
+            done();
+        });
+
+    });
+    it('should fail if the rule and data field is more than 2 nested level', (done) => {
+        const body = {
+            rule: { field: "missions.cat.cat.bat", condition: "gte",condition_value: 30 },
+            data: {name: "James Holden", crew: "Rocinante", age: 34, position: "Captain", missions: { cat:{ cat: { bat: 29}}}},
+        };
+        chai.request(app)
+        .post('/validate-rule')
+        .send(body)
+        .end((err, res) => {
+            expect(res.status).to.equal(400);
+        expect(res.body.status).to.equal('error');
+           expect(res.body.message).to.equal('field missions.cat.cat.bat nesting should not be more than two levels.')
+            done();
+        });
+
+    });
+
+    it('should fail If the rule validation fails', (done) => {
+        const body = {
+            rule: { field: "missions", condition: "eq",condition_value: 30 },
+            data: {name: "James Holden", crew: "Rocinante", age: 34, position: "Captain", missions: 45},
+        };
+        chai.request(app)
+        .post('/validate-rule')
+        .send(body)
+        .end((err, res) => {
+       
+            expect(res.status).to.equal(400);
+            expect(res.body.data.validation).to.have.all.keys(['error', 'field_value', 'field', 'condition', 'condition_value']);
+            expect(res.body.data.validation.error).to.equal(true);
+            expect(res.body.message).to.equal('field missions failed validation.');
             done();
         });
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -146,6 +146,7 @@ describe('POST /validate-rule', () => {
         .post('/validate-rule')
         .send(body)
         .end((err, res) => {
+        
             expect(res.status).to.equal(400);
             expect(res.body.message).to.equal('field missions is missing from data.')
             done();
@@ -153,4 +154,22 @@ describe('POST /validate-rule', () => {
 
     });
 
+
+    it('should accept JSON data containing a rule and data field to validate the rule against.', (done) => {
+        const body = {
+            rule: { field: "missions", condition: "gte",condition_value: 30 },
+            data: {name: "James Holden", crew: "Rocinante", age: 34, position: "Captain", missions: 45},
+        };
+        chai.request(app)
+        .post('/validate-rule')
+        .send(body)
+        .end((err, res) => {
+        console.log(res.body)
+            expect(res.status).to.equal(200);
+            expect(res.body.message).to.equal('field missions successfully validated.')
+            done();
+        });
+
+    });
+    
 });

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,8 +1,21 @@
 import chai , {expect} from 'chai';
+import chaiHttp from 'chai-http';
+import app from '../src'; 
+
+chai.use(chaiHttp);
 
 
 describe('test', () => {
-    it('should run a fake test', () => {
-        expect(true).to.be.equal(true);
+    it('should get my personal info', (done) => {
+        chai.request(app)
+        .get('/')
+        .end((err, res) =>{
+            expect(res.status).to.be.equal(200);
+            
+        expect(res.body).to.be.a('object');
+        expect(res.body.data).to.have.all.keys(['name', 'github', 'email', 'twitter', 'mobile']);
+        expect(res.body.data['github']).to.include('@')
+        done();
+        } )
     });
 });


### PR DESCRIPTION
### What does this PR do?
- Creates `POST /validate-rule` 

### Steps Taken to reproduce
- Write tests that conform to the API requirement as listed out in the [gist outlined here](https://flwat.glitch.me/fulltime.html) fail initially
- Build out API specs that pass the test

### How to test this API?
- Clone the repo and checkout to `ft-post-endpoint` then pull the contents of this branch
- Start the dev server using `npm run dev:start`
- Make a POST request by passing the following in the JSON body request :

>{
>  "rule": {
>    "field": "missions"
>    "condition": "gte",
>    "condition_value": 30
>  },
>  "data": {
>    "name": "James Holden",
>    "crew": "Rocinante",
>    "age": 34,
>    "position": "Captain",
>    "missions": 45
>  }
>}

- Expect a response like this :
> {
>  "message": "field missions successfully validated."
>  "status": "success",
>  "data": {
>    "validation": {
>      "error": false,
>      "field": "missions",
>      "field_value": 30,
>      "condition": "gte",
>      "condition_value: 30
>    }
>  }
>}

### Any Background Context?
- No